### PR TITLE
Aggiunto controllo in fase di modifica dei parametri di configurazione

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
   - Gestiti timezone diversi da Europe/Rome nella creazione delle missioni via REST.
   - Aggiunto il campo ContractType nel Contract che specifica se un dipendente è strutturato, interinale o non strutturato.
+  - Aggiunto controllo in fase di modifica della configurazione di una persona che sospende l'operazione se la data di attivazione del
+    dipendente e la data di inizio del parametro di configurazione sono diverse.
   
 ### Changed
   - Modificata interfaccia per specificare quale debba essere la discriminante se far finire un dipendente nella lista del personale che

--- a/app/controllers/Configurations.java
+++ b/app/controllers/Configurations.java
@@ -437,6 +437,13 @@ public class Configurations extends Controller {
     notFoundIfNull(configuration.getPerson().getOffice());
 
     rules.checkIfPermitted(configuration.getPerson().getOffice());
+    
+    if (!configuration.getBeginDate().isEqual(configuration.getPerson().getBeginDate())) {
+      flash.error("La data di inizio della configurazione (%s) e la data di attivazione della persona (%s) sono diverse. "
+          + "Modificare la data di attivazione della persona nei dati anagrafici per procedere con la modifica di questo parametro.", 
+          configuration.getBeginDate(), configuration.getPerson().getBeginDate());
+      personShow(configuration.getPerson().id);
+    }
 
     PersonConfiguration newConfiguration = (PersonConfiguration) compute(configuration,
         configuration.getEpasParam(), configurationDto);


### PR DESCRIPTION
di un dipendente che controlla che le date di attivazione della persona e di inizio del parametro selezionato siano uguali per poter procedere con la modifica del valore.