### PR TITLE
Corretto il calcolo delle ore di straordinario disponibile nel gruppo nel caso in cui la configurazione della sede dica che deve essere presente la doppia approvazione.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
   - Aggiunto il permesso per l'utente per vedere quando, nel mese, sono state maturate le ore per gli straordinari
 
+### Changed
+  - Corretto il calcolo delle ore di straordinario disponibile nel gruppo nel caso in cui la configurazione della sede dica che
+    deve essere presente la doppia approvazione.
+  - Resa modificabile la motivazione alla base della richiesta di straordinario da parte dei soggetti approvatori.
+
 ## [2.27.0] - 2025-10-16
 ### Added
   - Aggiunta differenziazione nel conteggio del residuo per straordinari tra personale turnista e non turnista.

--- a/app/controllers/CompetenceRequests.java
+++ b/app/controllers/CompetenceRequests.java
@@ -760,5 +760,20 @@ public class CompetenceRequests extends Controller {
     flash.error("Richiesta respinta");
     render("@show", competenceRequest, user);
   }
+  
+  public static void updateNote(long id, boolean confirmed, String reason) {
+    CompetenceRequest competenceRequest = CompetenceRequest.findById(id);
+    if (!confirmed) {
+      confirmed = true;      
+      render("@updateNote", confirmed, competenceRequest);
+    }
+    competenceRequest.setNote(reason);
+    competenceRequest.save();
+    flash.success("Modificata motivazione della richiesta di %s", competenceRequest.getPerson());
+    listToApprove(competenceRequest.getType());
+    
+  }
+  
+  
 }
 

--- a/app/manager/flows/CompetenceRequestManager.java
+++ b/app/manager/flows/CompetenceRequestManager.java
@@ -771,7 +771,7 @@ public class CompetenceRequestManager {
     }
     int overtimePendingRequests = !results.isEmpty() ? 
         results.stream().mapToInt(cr -> cr.getValueRequested()).sum() : 0;
-    if (config.managerApprovalRequired) {
+    if (approver.hasRoles(Role.GROUP_MANAGER)) {
 
       /* 
        * Controllo la quantità già assegnata nel corso dell'anno agli appartenenti al gruppo 
@@ -804,7 +804,7 @@ public class CompetenceRequestManager {
 
 
     }
-    if (config.officeHeadApprovalRequired) {
+    if (approver.hasRoles(Role.SEAT_SUPERVISOR)) {
       /*
        * Controllo la quantità già assegnata nel corso dell'anno ai dipendenti della sede
        */

--- a/app/views/CompetenceRequests/_overtimeSituation.html
+++ b/app/views/CompetenceRequests/_overtimeSituation.html
@@ -35,7 +35,7 @@
 	</div>
 	#{if showOvertimeAvailableHours}
 	<div class="container-fluid">
-		<h4>Quantità di straordinari ancora disponibili da assegnare dal monte ore #{if isSeatSupervisor}della sede#{/if}#{else} del gruppo#{/else}: ${hoursAvailable} ore</h4>
+		<h4>Quantità di straordinari ancora disponibili da assegnare dal monte ore #{if isSeatSupervisor}della sede #{/if}#{else} del gruppo#{/else}: ${hoursAvailable} ore</h4>
 	</div>
 	#{/if}
 	#{if enabledOvertimePerPerson}

--- a/app/views/CompetenceRequests/tableElements/_table.html
+++ b/app/views/CompetenceRequests/tableElements/_table.html
@@ -129,11 +129,13 @@
       			</a>
       			#{/secure.check}
       			</td>
-      			<td #{if item.note != null && !item.note.equals("")}
-      				webui-popover-hover data-content="${item.note}">
-      				<i class="fa fa-exclamation-triangle fa-2x text-danger" aria-hidden="true" ></i>
-      				#{/if}
-      			</td>
+      			<td>
+					#{secure.link @CompetenceRequests.updateNote(item.id, type)}	
+					<a href="@{CompetenceRequests.updateNote(item.id, type)}" data-async-modal="#defaultModal" title="Leggi">
+					<i class="fa fa-eye" aria-hidden="true"></i> Leggi
+					</a>					
+					#{/secure.link}
+				</td>
 			</tr>
 		#{/list}
 	</tbody>

--- a/conf/permissions.drl
+++ b/conf/permissions.drl
@@ -541,6 +541,7 @@ when
   		"CompetenceRequests.edit",
   		"CompetenceRequests.save",
   		"CompetenceRequests.show",
+  		"CompetenceRequests.updateNote",
   		"CompetenceRequests.listToApprove",
   		"CompetenceRequests.changeReperibilityToApprove",
      	"ReperibilityCalendar.show",
@@ -565,6 +566,7 @@ when
   		"CompetenceRequests.edit",
   		"CompetenceRequests.save",
   		"CompetenceRequests.show",
+  		"CompetenceRequests.updateNote",
   		"CompetenceRequests.listToApprove",
   		"CompetenceRequests.changeReperibilityToApprove",
         "ReperibilityCalendar.show",
@@ -752,6 +754,7 @@ when
 		"CompetenceRequests.edit",
 		"CompetenceRequests.save",
 		"CompetenceRequests.show",
+		"CompetenceRequests.updateNote",
 		"CompetenceRequests.overtimes",
 		
      	/* Ferie */
@@ -1021,6 +1024,7 @@ when
 			"AbsenceRequests.disapproval",
 
 			"CompetenceRequests.show",
+			"CompetenceRequests.updateNote",
 			"CompetenceRequests.approval",
 			"CompetenceRequests.disapproval",
 			"CompetenceRequests.managerApproval",
@@ -1098,7 +1102,8 @@ when
 			"CompetenceRequests.overtimesToApprove",	
 			"CompetenceRequests.overtimesToApproveInAdvance",		
 			"CompetenceRequests.managerApproval",
-			"CompetenceRequests.show"
+			"CompetenceRequests.show",
+			"CompetenceRequests.updateNote"
 			
 		), target == $cr, granted == false)
 then
@@ -1655,6 +1660,7 @@ when
 		"AbsenceRequests.approval",
 		"AbsenceRequests.disapproval",
 		"CompetenceRequests.show",
+		"CompetenceRequests.updateNote",
 		"CompetenceRequests.list",
 		"CompetenceRequests.approval",
 		"CompetenceRequests.disapproval",
@@ -1750,6 +1756,7 @@ when
 
 		"AbsenceRequests.show",
 		"CompetenceRequests.show",
+		"CompetenceRequests.updateNote",
 		"CompetenceRequests.list",
 		"CompetenceRequests.approval",
 		"CompetenceRequests.disapproval",
@@ -1834,6 +1841,7 @@ when
  $cr: CompetenceRequest(officeHeadApprovalRequired == true, !isOfficeHeadApproved(), flowEnded == false)
  $c: PermissionCheck(action in (
 		"CompetenceRequests.show",
+		"CompetenceRequests.updateNote",
 		"CompetenceRequests.approval",
 		"CompetenceRequests.disapproval"
 		), target == $cr, granted == false)


### PR DESCRIPTION
Resa modificabile la motivazione alla base della richiesta di straordinario da parte dei soggetti approvatori.