### PR TITLE
521 creare un meccanismo per generare i piani ferie dei part time ciclici

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.30.2] - Unreleased
+### Added
+  - Aggiunto codice NO_STAMP a uso interno e che decurta le ferie da utilizzare per i part time ciclici nei periodi
+    in cui il dipendente non va a lavoro così da decurtargli correttamente le ferie.
+
 ## [2.30.2] - 2026-02-26
 ### Changed
   - Risolto il caso in cui un responsabile di gruppo sia un tecnico/amministrativo e non può approvare le richieste

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.30.2] - Unreleased
+## [2.31.0] - Unreleased
 ### Added
   - Aggiunto codice NO_STAMP a uso interno e che decurta le ferie da utilizzare per i part time ciclici nei periodi
     in cui il dipendente non va a lavoro così da decurtargli correttamente le ferie.

--- a/app/models/absences/definitions/DefaultAbsenceType.java
+++ b/app/models/absences/definitions/DefaultAbsenceType.java
@@ -2822,6 +2822,11 @@ public enum DefaultAbsenceType {
       ImmutableSet.of(JustifiedTypeName.all_day), 0, false, 
       MealTicketBehaviour.notAllowMealTicket, 0, null, Sets.newHashSet(), null,
       null, false, true, true, null),
+  
+  A_NOSTAMP("no-stamp", "codice per giustificare mancata presenza in caso di orari strani", true,
+      ImmutableSet.of(JustifiedTypeName.all_day), 0, true, 
+      MealTicketBehaviour.notAllowMealTicket, 0, null, Sets.newHashSet(), null,
+      null, false, true, true, null),
 
   A_35R("35R", "dottorato di ricerca retribuito", false, ImmutableSet.of(JustifiedTypeName.all_day),
       0, true, MealTicketBehaviour.notAllowMealTicket, 0, null, Sets.newHashSet(), 

--- a/app/models/absences/definitions/DefaultTakable.java
+++ b/app/models/absences/definitions/DefaultTakable.java
@@ -698,7 +698,7 @@ public enum DefaultTakable {
 
           DefaultAbsenceType.A_681, DefaultAbsenceType.A_682, DefaultAbsenceType.A_683, 
           DefaultAbsenceType.A_441, DefaultAbsenceType.A_6N, DefaultAbsenceType.A_442,
-
+          DefaultAbsenceType.A_NOSTAMP,
           DefaultAbsenceType.A_67, DefaultAbsenceType.A_80, 
           DefaultAbsenceType.A_81, DefaultAbsenceType.A_82,
           DefaultAbsenceType.A_83, DefaultAbsenceType.A_84, 
@@ -737,7 +737,7 @@ public enum DefaultTakable {
           DefaultAbsenceType.A_FA1, DefaultAbsenceType.A_FA2, 
           DefaultAbsenceType.A_FA3, DefaultAbsenceType.A_FA4, DefaultAbsenceType.A_FA5, 
           DefaultAbsenceType.A_FA6, DefaultAbsenceType.A_FA7,
-
+          DefaultAbsenceType.A_NOSTAMP,
           DefaultAbsenceType.A_33, DefaultAbsenceType.A_33B, DefaultAbsenceType.A_33C,
           DefaultAbsenceType.A_34, DefaultAbsenceType.A_38, DefaultAbsenceType.A_39,
           DefaultAbsenceType.A_681, DefaultAbsenceType.A_682, DefaultAbsenceType.A_683, 
@@ -888,7 +888,7 @@ public enum DefaultTakable {
           DefaultAbsenceType.A_132, DefaultAbsenceType.A_133, 
           DefaultAbsenceType.A_14, DefaultAbsenceType.A_142, 
           DefaultAbsenceType.A_143, DefaultAbsenceType.A_54A17,
-          DefaultAbsenceType.A_98CV,
+          DefaultAbsenceType.A_98CV, DefaultAbsenceType.A_NOSTAMP,
           DefaultAbsenceType.A_C17, DefaultAbsenceType.A_C18,
           DefaultAbsenceType.A_C16, DefaultAbsenceType.A_35R,
           DefaultAbsenceType.A_54B, DefaultAbsenceType.A_54TD,
@@ -912,7 +912,7 @@ public enum DefaultTakable {
           DefaultAbsenceType.A_132, DefaultAbsenceType.A_133, 
           DefaultAbsenceType.A_14, DefaultAbsenceType.A_142, 
           DefaultAbsenceType.A_143, DefaultAbsenceType.A_54A17,
-          DefaultAbsenceType.A_98CV,
+          DefaultAbsenceType.A_98CV, DefaultAbsenceType.A_NOSTAMP,
           DefaultAbsenceType.A_C17, DefaultAbsenceType.A_C18,
           DefaultAbsenceType.A_C16, DefaultAbsenceType.A_35R,
           DefaultAbsenceType.A_54B, DefaultAbsenceType.A_54TD,


### PR DESCRIPTION
Aggiunto codice d'assenza che decurta le ferie a uso interno per la gestione delle ferie dei part time ciclici.